### PR TITLE
Use hex encoding without prefix

### DIFF
--- a/lib/src/main/kotlin/org/walletconnect/impls/MoshiPayloadAdapter.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/MoshiPayloadAdapter.kt
@@ -15,7 +15,7 @@ import org.walletconnect.Session
 import org.walletconnect.nullOnThrow
 import org.walletconnect.types.intoMap
 import org.walleth.khex.hexToByteArray
-import org.walleth.khex.toHexString
+import org.walleth.khex.toNoPrefixHexString
 import java.security.SecureRandom
 
 class MoshiPayloadAdapter(moshi: Moshi) : Session.PayloadAdapter {
@@ -84,9 +84,9 @@ class MoshiPayloadAdapter(moshi: Moshi) : Session.PayloadAdapter {
 
         return payloadAdapter.toJson(
             EncryptedPayload(
-                outBuf.toHexString(),
-                hmac = hmacResult.toHexString(),
-                iv = iv.toHexString()
+                outBuf.toNoPrefixHexString(),
+                hmac = hmacResult.toNoPrefixHexString(),
+                iv = iv.toNoPrefixHexString()
             )
         )
     }

--- a/lib/src/test/java/org/walletconnect/WalletConnectBridgeRepositoryIntegrationTest.kt
+++ b/lib/src/test/java/org/walletconnect/WalletConnectBridgeRepositoryIntegrationTest.kt
@@ -2,6 +2,7 @@ package org.walletconnect
 
 import com.squareup.moshi.Moshi
 import okhttp3.OkHttpClient
+import org.junit.Test
 import org.walletconnect.impls.FileWCSessionStore
 import org.walletconnect.impls.MoshiPayloadAdapter
 import org.walletconnect.impls.OkHttpTransport
@@ -22,7 +23,7 @@ class WalletConnectBridgeRepositoryIntegrationTest {
         val sessionDir = File("build/tmp/").apply { mkdirs() }
         val sessionStore = FileWCSessionStore(File(sessionDir, "test_store.json").apply { createNewFile() }, moshi)
         val uri =
-            "wc:31d92639-d7ab-452f-811e-336309ad20b0@1?bridge=https%3A%2F%2Fbridge.walletconnect.org&key=d2f410444aaac3f1410a922b520d5ca575332ae692d1d7b6678f0f5a444aaaa3"
+            "wc:9adf0090-de9d-4511-9142-7e7a58d9024f@1?bridge=https%3A%2F%2Fbridge.walletconnect.org&key=e0f0a33a64dca857356db1011829d4a384f85381aa6c027a50c346a5210d9063"
 
         val config = Session.Config.fromWCUri(uri)
         val session = WCSession(


### PR DESCRIPTION
- WalletConnect expects the hex strings to be without the "0x" prefix