### PR TITLE
Added client data to session update (e.g. approve session)

### DIFF
--- a/lib/src/main/kotlin/org/walletconnect/Session.kt
+++ b/lib/src/main/kotlin/org/walletconnect/Session.kt
@@ -125,8 +125,7 @@ interface Session {
         val url: String? = null,
         val name: String? = null,
         val description: String? = null,
-        val icons: List<String>? = null,
-        val ssl: Boolean? = null
+        val icons: List<String>? = null
     )
 
     data class SessionParams(val approved: Boolean, val chainId: Long?, val accounts: List<String>?, val peerData: PeerData?)

--- a/lib/src/main/kotlin/org/walletconnect/Session.kt
+++ b/lib/src/main/kotlin/org/walletconnect/Session.kt
@@ -49,7 +49,7 @@ interface Session {
 
         fun sessionApproved()
 
-        fun sessionClosed(msg: String?)
+        fun sessionClosed()
     }
 
     interface PayloadAdapter {
@@ -129,6 +129,6 @@ interface Session {
         val ssl: Boolean? = null
     )
 
-    data class SessionParams(val approved: Boolean, val chainId: Long?, val accounts: List<String>?, val message: String?)
+    data class SessionParams(val approved: Boolean, val chainId: Long?, val accounts: List<String>?, val peerData: PeerData?)
     data class Error(val code: Long, val message: String)
 }

--- a/lib/src/main/kotlin/org/walletconnect/impls/MoshiPayloadAdapter.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/MoshiPayloadAdapter.kt
@@ -131,11 +131,10 @@ class MoshiPayloadAdapter(moshi: Moshi) : Session.PayloadAdapter {
         val data = params.firstOrNull() as? Map<*, *> ?: throw IllegalArgumentException("Invalid params")
         val approved = data["approved"] as? Boolean ?: throw IllegalArgumentException("approved missing")
         val chainId = data["chainId"] as? Long
-        val message = data["message"] as? String
         val accounts = nullOnThrow { (data["accounts"] as? List<*>)?.toStringList() }
         return Session.MethodCall.SessionUpdate(
             getId(),
-            Session.SessionParams(approved, chainId, accounts, message)
+            Session.SessionParams(approved, chainId, accounts, nullOnThrow { data.extractPeerData() })
         )
     }
 

--- a/lib/src/main/kotlin/org/walletconnect/impls/MoshiPayloadAdapter.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/MoshiPayloadAdapter.kt
@@ -192,9 +192,8 @@ class MoshiPayloadAdapter(moshi: Moshi) : Session.PayloadAdapter {
         val description = this?.get("description") as? String
         val url = this?.get("url") as? String
         val name = this?.get("name") as? String
-        val ssl = (this?.get("ssl") as? Boolean) ?: false
         val icons = nullOnThrow { (this?.get("icons") as? List<*>)?.toStringList() }
-        return Session.PeerMeta(url, name, description, icons, ssl)
+        return Session.PeerMeta(url, name, description, icons)
     }
 
     private fun List<*>.toStringList(): List<String> =

--- a/lib/src/main/kotlin/org/walletconnect/types/TypeMapConversion.kt
+++ b/lib/src/main/kotlin/org/walletconnect/types/TypeMapConversion.kt
@@ -2,20 +2,23 @@ package org.walletconnect.types
 
 import org.walletconnect.Session
 
+fun Session.PeerMeta.intoMap(params: MutableMap<String, Any?> = mutableMapOf()) =
+    params.also {
+        params["peerMeta"] =
+            mutableMapOf<String, Any>(
+                "description" to (description ?: ""),
+                "url" to (url ?: ""),
+                "name" to (name ?: "")
+            ).apply {
+                ssl?.let { put("ssl", it) }
+                icons?.let { put("icons", it) }
+            }
+    }
 
 fun Session.PeerData.intoMap(params: MutableMap<String, Any?> = mutableMapOf()) =
     params.also {
         params["peerId"] = this.id
-        params["peerMeta"] = (this.meta?.let { meta ->
-            mutableMapOf<String, Any>(
-                "description" to (meta.description ?: ""),
-                "url" to (meta.url ?: ""),
-                "name" to (meta.name ?: "")
-            ).apply {
-                meta.ssl?.let { put("ssl", it) }
-                meta.icons?.let { put("icons", it) }
-            }
-        } ?: emptyMap<String, Any>())
+        this.meta?.intoMap(params)
     }
 
 fun Session.SessionParams.intoMap(params: MutableMap<String, Any?> = mutableMapOf()) =
@@ -23,7 +26,7 @@ fun Session.SessionParams.intoMap(params: MutableMap<String, Any?> = mutableMapO
         it["approved"] = approved
         it["chainId"] = chainId
         it["accounts"] = accounts
-        it["message"] = message
+        this.peerData?.intoMap(params)
     }
 
 fun Session.Error.intoMap(params: MutableMap<String, Any?> = mutableMapOf()) =

--- a/lib/src/main/kotlin/org/walletconnect/types/TypeMapConversion.kt
+++ b/lib/src/main/kotlin/org/walletconnect/types/TypeMapConversion.kt
@@ -10,7 +10,6 @@ fun Session.PeerMeta.intoMap(params: MutableMap<String, Any?> = mutableMapOf()) 
                 "url" to (url ?: ""),
                 "name" to (name ?: "")
             ).apply {
-                ssl?.let { put("ssl", it) }
                 icons?.let { put("icons", it) }
             }
     }

--- a/lib/src/test/java/org/walletconnect/WalletConnectBridgeRepositoryIntegrationTest.kt
+++ b/lib/src/test/java/org/walletconnect/WalletConnectBridgeRepositoryIntegrationTest.kt
@@ -23,7 +23,7 @@ class WalletConnectBridgeRepositoryIntegrationTest {
         val sessionDir = File("build/tmp/").apply { mkdirs() }
         val sessionStore = FileWCSessionStore(File(sessionDir, "test_store.json").apply { createNewFile() }, moshi)
         val uri =
-            "wc:9adf0090-de9d-4511-9142-7e7a58d9024f@1?bridge=https%3A%2F%2Fbridge.walletconnect.org&key=e0f0a33a64dca857356db1011829d4a384f85381aa6c027a50c346a5210d9063"
+            "wc:56f58ba1-8012-40c1-a5be-cf24b1f4884f@1?bridge=https%3A%2F%2Fbridge.walletconnect.org&key=60f6dddb470b32863dba98ba3c7d4d8965ad6dc6ac205108c873d2cbd0ba7f1e"
 
         val config = Session.Config.fromWCUri(uri)
         val session = WCSession(
@@ -34,10 +34,24 @@ class WalletConnectBridgeRepositoryIntegrationTest {
             Session.PeerMeta(name = "WC Unit Test")
         )
 
+        session.addCallback(object : Session.Callback {
+            override fun handleMethodCall(call: Session.MethodCall) {
+                System.out.println("handleMethodCall: $call")
+            }
+
+            override fun sessionApproved() {
+                System.out.println("sessionApproved()")
+            }
+
+            override fun sessionClosed() {
+                System.out.println("sessionClosed()")
+            }
+
+        })
         session.init()
         Thread.sleep(2000)
         session.approve(listOf("0x00000000000000000000000000000000DeaDBEAF"), 4)
-        Thread.sleep(10000)
+        Thread.sleep(100000)
     }
 }
 


### PR DESCRIPTION
- After wc_exchangeKey was removed we need to send the client data (id + meta) with session updates