### PR TITLE
Fix "eth_sendTransaction" with no value

### DIFF
--- a/lib/src/main/kotlin/org/walletconnect/impls/MoshiPayloadAdapter.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/MoshiPayloadAdapter.kt
@@ -130,7 +130,7 @@ class MoshiPayloadAdapter(moshi: Moshi) : Session.PayloadAdapter {
         val nonce = data["nonce"] as? String ?: (data["nonce"] as? Double)?.toLong()?.toString()
         val gasPrice = data["gasPrice"] as? String
         val gasLimit = data["gasLimit"] as? String
-        val value = data["value"] as? String ?: throw IllegalArgumentException("value key missing")
+        val value = data["value"] as? String ?: "0x0"
         val txData = data["data"] as? String ?: throw IllegalArgumentException("data key missing")
         return Session.MethodCall.SendTransaction(getId(), from, to, nonce, gasPrice, gasLimit, value, txData)
     }


### PR DESCRIPTION
 Any `eth_sendTransaction` request without `value` is considered invalid by the library. But this is in fact allowed by the specification.
 see https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sendtransaction

This issue is reproducible by using Bamboorelay to trade some tokens.
We will then receive a request to approve the ERC20 token usage. This is a `eth_sendTransaction` request with no `value` but with some `data` to make the contract call