### PR TITLE
Fix gas limit parameter

### DIFF
--- a/lib/src/main/kotlin/org/walletconnect/impls/MoshiPayloadAdapter.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/MoshiPayloadAdapter.kt
@@ -128,7 +128,8 @@ class MoshiPayloadAdapter(moshi: Moshi) : Session.PayloadAdapter {
         val to = data["to"] as? String ?: throw IllegalArgumentException("to key missing")
         val nonce = data["nonce"] as? String ?: (data["nonce"] as? Double)?.toLong()?.toString()
         val gasPrice = data["gasPrice"] as? String
-        val gasLimit = data["gasLimit"] as? String
+        // "gasLimit" was used in older versions of the library, kept here as a fallback for compatibility
+        val gasLimit = data["gas"] as? String ?: data["gasPrice"] as? String
         val value = data["value"] as? String ?: "0x0"
         val txData = data["data"] as? String ?: throw IllegalArgumentException("data key missing")
         return Session.MethodCall.SendTransaction(getId(), from, to, nonce, gasPrice, gasLimit, value, txData)
@@ -186,7 +187,7 @@ class MoshiPayloadAdapter(moshi: Moshi) : Session.PayloadAdapter {
                 "to" to to,
                 "nonce" to nonce,
                 "gasPrice" to gasPrice,
-                "gasLimit" to gasLimit,
+                "gas" to gasLimit,
                 "value" to value,
                 "data" to data
             )

--- a/lib/src/main/kotlin/org/walletconnect/impls/MoshiPayloadAdapter.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/MoshiPayloadAdapter.kt
@@ -129,7 +129,7 @@ class MoshiPayloadAdapter(moshi: Moshi) : Session.PayloadAdapter {
         val nonce = data["nonce"] as? String ?: (data["nonce"] as? Double)?.toLong()?.toString()
         val gasPrice = data["gasPrice"] as? String
         // "gasLimit" was used in older versions of the library, kept here as a fallback for compatibility
-        val gasLimit = data["gas"] as? String ?: data["gasPrice"] as? String
+        val gasLimit = data["gas"] as? String ?: data["gasLimit"] as? String
         val value = data["value"] as? String ?: "0x0"
         val txData = data["data"] as? String ?: throw IllegalArgumentException("data key missing")
         return Session.MethodCall.SendTransaction(getId(), from, to, nonce, gasPrice, gasLimit, value, txData)


### PR DESCRIPTION
The library was incorrectly using `gasLimit` instead of `gas`. Fixed with the correct value, using `gasLimit` as a fallback for compatibility 