### PR TITLE
Fixed sample app for 0.9.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
                 'minSdk'                  : 14,
                 'compileSdk'              : 28,
                 'buildTools'              : '28.0.3',
-                'androidPlugin'           : '3.4.0',
+                'androidPlugin'           : '4.0.0',
 
                 androidx_app_compat       : '1.0.2',
                 androidx_card_view        : '1.0.0',
@@ -28,14 +28,18 @@ buildscript {
                         'gradlePlugin': "com.android.tools.build:gradle:${versions.androidPlugin}",
                 ]
         ]
+        versions.kotlin = '1.3.72'
     }
 
     repositories {
+        google()
+        jcenter()
         gradlePluginPortal()
-	mavenCentral()
+        mavenCentral()
     }
 
     dependencies {
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.38.0'
         // How can we move this to the sample folder

--- a/lib/src/main/kotlin/org/walletconnect/Session.kt
+++ b/lib/src/main/kotlin/org/walletconnect/Session.kt
@@ -32,7 +32,9 @@ interface Session {
             val key: String,
             val protocol: String = "wc",
             val version: Int = 1
-    )
+    ) {
+        fun toWCUri() = "wc:$handshakeTopic@$version?bridge=${URLEncoder.encode(bridge, "UTF-8")}&key=$key"
+    }
 
     data class Config(
             val handshakeTopic: String,

--- a/sample/app/gradle.properties
+++ b/sample/app/gradle.properties
@@ -1,0 +1,15 @@
+## For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+#
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+#Fri May 21 10:30:53 SAST 2021
+android.enableJetifier=true
+android.useAndroidX=true

--- a/sample/app/src/main/java/io/walletconnect/example/ExampleApplication.kt
+++ b/sample/app/src/main/java/io/walletconnect/example/ExampleApplication.kt
@@ -43,13 +43,13 @@ class ExampleApplication : MultiDexApplication() {
         private lateinit var moshi: Moshi
         private lateinit var bridge: BridgeServer
         private lateinit var storage: WCSessionStore
-        lateinit var config: Session.Config
+        lateinit var config: Session.FullyQualifiedConfig
         lateinit var session: Session
 
         fun resetSession() {
             nullOnThrow { session }?.clearCallbacks()
             val key = ByteArray(32).also { Random().nextBytes(it) }.toNoPrefixHexString()
-            config = Session.Config(UUID.randomUUID().toString(), "http://localhost:${BridgeServer.PORT}", key)
+            config = Session.FullyQualifiedConfig(UUID.randomUUID().toString(), "http://localhost:${BridgeServer.PORT}", key)
             session = WCSession(config,
                     MoshiPayloadAdapter(moshi),
                     storage,

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
-include ':lib' //, ':sample:app'
+include ':lib', ':sample:app'
 


### PR DESCRIPTION
Updated the repo so that the sample app can build with ease.  This would probably require a version bump with the changes to `FullyQualifiedConfig`.

- Fixed the sample app
- Added `toWCUri()` on `FullyQualifiedConfig`