### PR TITLE
Create GsonPayloadAdapter to encrypt/decrypt WalletConnect payloads

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,10 @@ buildscript {
                 moshi                     : '1.8.0',
                 okhttp                    : '3.11.0',
                 jupiter                   : '5.7.0',
+                gson                      : '2.8.7',
+                khex                      : '1.1.0',
+                bcprov                    : '1.68',
+                assertjCore               : '3.19.0',
 
                 'minSdk'                  : 14,
                 'compileSdk'              : 28,

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -9,18 +9,19 @@ repositories {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlin"
 
-    implementation "com.github.komputing:khex:1.1.0"
+    implementation "com.github.komputing:khex:${versions.khex}"
 
-    implementation "org.bouncycastle:bcprov-jdk15to18:1.68"
+    implementation "org.bouncycastle:bcprov-jdk15to18:${versions.bcprov}"
 
-    implementation 'com.squareup.moshi:moshi:1.8.0'
+    implementation "com.google.code.gson:gson:${versions.gson}"
+    implementation "com.squareup.moshi:moshi:${versions.moshi}"
     // TODO: it would be better to use the generated adapter by moshi
     // but for that we should move the implementations in different modules
     //kapt "com.squareup.moshi:moshi-kotlin-codegen:$versions.moshi"
 
     implementation "com.squareup.okhttp3:okhttp:$versions.okhttp"
 
-    testImplementation 'org.assertj:assertj-core:3.19.0'
+    testImplementation "org.assertj:assertj-core:${versions.assertjCore}"
     testImplementation "org.junit.jupiter:junit-jupiter-api:${versions.jupiter}"
     testImplementation "org.junit.jupiter:junit-jupiter-params:${versions.jupiter}"
     testRuntime "org.junit.jupiter:junit-jupiter-engine:${versions.jupiter}"

--- a/lib/src/main/kotlin/org/walletconnect/EncryptedPayload.kt
+++ b/lib/src/main/kotlin/org/walletconnect/EncryptedPayload.kt
@@ -1,0 +1,19 @@
+package org.walletconnect
+
+import com.google.gson.annotations.SerializedName
+import com.squareup.moshi.Json
+
+data class EncryptedPayload(
+
+    @Json(name = "data")
+    @SerializedName("data")
+    val data: String,
+
+    @Json(name = "iv")
+    @SerializedName("iv")
+    val iv: String,
+
+    @Json(name = "hmac")
+    @SerializedName("hmac")
+    val hmac: String
+)

--- a/lib/src/main/kotlin/org/walletconnect/PayloadEncryptionHelper.kt
+++ b/lib/src/main/kotlin/org/walletconnect/PayloadEncryptionHelper.kt
@@ -1,0 +1,76 @@
+package org.walletconnect
+
+import org.bouncycastle.crypto.digests.SHA256Digest
+import org.bouncycastle.crypto.engines.AESEngine
+import org.bouncycastle.crypto.macs.HMac
+import org.bouncycastle.crypto.modes.CBCBlockCipher
+import org.bouncycastle.crypto.paddings.PKCS7Padding
+import org.bouncycastle.crypto.paddings.PaddedBufferedBlockCipher
+import org.bouncycastle.crypto.params.KeyParameter
+import org.bouncycastle.crypto.params.ParametersWithIV
+import org.komputing.khex.decode
+import org.komputing.khex.extensions.toNoPrefixHexString
+import java.security.SecureRandom
+
+class PayloadEncryptionHelper {
+
+    fun decryptPayload(encryptedPayload: EncryptedPayload, key: String): ByteArray {
+        // TODO verify hmac
+
+        val padding = PKCS7Padding()
+        val aes = PaddedBufferedBlockCipher(
+            CBCBlockCipher(AESEngine()),
+            padding
+        )
+        val ivAndKey = ParametersWithIV(
+            KeyParameter(decode(key)),
+            decode(encryptedPayload.iv)
+        )
+        aes.init(false, ivAndKey)
+
+        val encryptedData = decode(encryptedPayload.data)
+        val minSize = aes.getOutputSize(encryptedData.size)
+        val outBuf = ByteArray(minSize)
+        var len = aes.processBytes(encryptedData, 0, encryptedData.size, outBuf, 0)
+        len += aes.doFinal(outBuf, len)
+
+        return outBuf.copyOf(len)
+    }
+
+    fun encryptPayload(bytesData: ByteArray, key: String): EncryptedPayload {
+        val hexKey = decode(key)
+        val iv = createRandomBytes(16)
+
+        val padding = PKCS7Padding()
+        val aes = PaddedBufferedBlockCipher(
+            CBCBlockCipher(AESEngine()),
+            padding
+        )
+        aes.init(true, ParametersWithIV(KeyParameter(hexKey), iv))
+
+        val minSize = aes.getOutputSize(bytesData.size)
+        val outBuf = ByteArray(minSize)
+        val length1 = aes.processBytes(bytesData, 0, bytesData.size, outBuf, 0)
+        aes.doFinal(outBuf, length1)
+
+        val hmac = HMac(SHA256Digest())
+        hmac.init(KeyParameter(hexKey))
+
+        val hmacResult = ByteArray(hmac.macSize)
+        hmac.update(outBuf, 0, outBuf.size)
+        hmac.update(iv, 0, iv.size)
+        hmac.doFinal(hmacResult, 0)
+
+        return EncryptedPayload(
+            outBuf.toNoPrefixHexString(),
+            hmac = hmacResult.toNoPrefixHexString(),
+            iv = iv.toNoPrefixHexString()
+        )
+    }
+
+    private fun createRandomBytes(i: Int) = ByteArray(i).also { SecureRandom().nextBytes(it) }
+
+    companion object {
+        fun getInstance() = PayloadEncryptionHelper()
+    }
+}

--- a/lib/src/main/kotlin/org/walletconnect/Session.kt
+++ b/lib/src/main/kotlin/org/walletconnect/Session.kt
@@ -77,7 +77,7 @@ interface Session {
 
     sealed class Status {
         data class Connected(val clientId: String, val peerId: String?) : Status()
-        object Disconnected : Status()
+        data class Disconnected(val forceToClearSession: Boolean) : Status()
         data class Approved(val clientId: String, val peerId: String?) : Status()
         object Closed : Status()
         data class Error(val throwable: Throwable) : Status()
@@ -103,7 +103,7 @@ interface Session {
 
         sealed class Status {
             object Connected : Status()
-            object Disconnected : Status()
+            data class Disconnected(val forceToClearSession: Boolean) : Status()
             data class Error(val throwable: Throwable) : Status()
         }
 

--- a/lib/src/main/kotlin/org/walletconnect/Session.kt
+++ b/lib/src/main/kotlin/org/walletconnect/Session.kt
@@ -76,9 +76,9 @@ interface Session {
     }
 
     sealed class Status {
-        object Connected : Status()
+        data class Connected(val clientId: String, val peerId: String?) : Status()
         object Disconnected : Status()
-        object Approved : Status()
+        data class Approved(val clientId: String, val peerId: String?) : Status()
         object Closed : Status()
         data class Error(val throwable: Throwable) : Status()
     }

--- a/lib/src/main/kotlin/org/walletconnect/Session.kt
+++ b/lib/src/main/kotlin/org/walletconnect/Session.kt
@@ -77,7 +77,7 @@ interface Session {
 
     sealed class Status {
         data class Connected(val clientId: String, val peerId: String?) : Status()
-        data class Disconnected(val forceToClearSession: Boolean) : Status()
+        data class Disconnected(val isSessionDeletionNeeded: Boolean) : Status()
         data class Approved(val clientId: String, val peerId: String?) : Status()
         object Closed : Status()
         data class Error(val throwable: Throwable) : Status()
@@ -103,7 +103,7 @@ interface Session {
 
         sealed class Status {
             object Connected : Status()
-            data class Disconnected(val forceToClearSession: Boolean) : Status()
+            data class Disconnected(val isSessionDeletionNeeded: Boolean) : Status()
             data class Error(val throwable: Throwable) : Status()
         }
 

--- a/lib/src/main/kotlin/org/walletconnect/Session.kt
+++ b/lib/src/main/kotlin/org/walletconnect/Session.kt
@@ -76,9 +76,9 @@ interface Session {
     }
 
     sealed class Status {
-        data class Connected(val clientId: String, val peerId: String?) : Status()
+        data class Connected(val clientId: String) : Status()
         data class Disconnected(val isSessionDeletionNeeded: Boolean) : Status()
-        data class Approved(val clientId: String, val peerId: String?) : Status()
+        data class Approved(val clientId: String) : Status()
         object Closed : Status()
         data class Error(val throwable: Throwable) : Status()
     }

--- a/lib/src/main/kotlin/org/walletconnect/Session.kt
+++ b/lib/src/main/kotlin/org/walletconnect/Session.kt
@@ -26,6 +26,8 @@ interface Session {
     fun removeCallback(cb: Callback)
     fun clearCallbacks()
 
+    fun disconnect()
+
     data class FullyQualifiedConfig(
             val handshakeTopic: String,
             val bridge: String,

--- a/lib/src/main/kotlin/org/walletconnect/Session.kt
+++ b/lib/src/main/kotlin/org/walletconnect/Session.kt
@@ -132,7 +132,7 @@ interface Session {
     sealed class MethodCall(private val internalId: Long) {
         fun id() = internalId
 
-        data class SessionRequest(val id: Long, val peer: PeerData) : MethodCall(id)
+        data class SessionRequest(val id: Long, val peer: PeerData, val chainId: Long?) : MethodCall(id)
 
         data class SessionUpdate(val id: Long, val params: SessionParams) : MethodCall(id)
 

--- a/lib/src/main/kotlin/org/walletconnect/impls/BasePayloadAdapter.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/BasePayloadAdapter.kt
@@ -1,0 +1,129 @@
+package org.walletconnect.impls
+
+import org.walletconnect.PayloadEncryptionHelper
+import org.walletconnect.Session
+import org.walletconnect.types.extractError
+import org.walletconnect.types.extractSessionParams
+import org.walletconnect.types.getId
+import org.walletconnect.types.intoMap
+import org.walletconnect.types.toSessionRequest
+
+abstract class BasePayloadAdapter : Session.PayloadAdapter {
+
+    protected val payloadEncryptionHelper = PayloadEncryptionHelper.getInstance()
+
+    protected fun parseJsonRpcMethodCall(jsonRpcMap: Map<String, Any?>?): Session.MethodCall {
+        return jsonRpcMap?.let {
+            try {
+                val method = it["method"]
+                when (method) {
+                    "wc_sessionRequest" -> it.toSessionRequest()
+                    "wc_sessionUpdate" -> it.toSessionUpdate()
+                    "eth_sendTransaction" -> it.toSendTransaction()
+                    "eth_sign" -> it.toSignMessage()
+                    null -> it.toResponse()
+                    else -> it.toCustom()
+                }
+            } catch (e: Exception) {
+                throw Session.MethodCallException.InvalidRequest(it.getId(), e.message ?: "Unknown error")
+            }
+        } ?: throw IllegalArgumentException("Invalid json")
+    }
+
+    private fun Map<String, *>.toSessionUpdate(): Session.MethodCall.SessionUpdate {
+        val params = this["params"] as? List<*> ?: throw IllegalArgumentException("params missing")
+        val data = params.firstOrNull() as? Map<String, *> ?: throw IllegalArgumentException("Invalid params")
+        return Session.MethodCall.SessionUpdate(
+            getId(),
+            data.extractSessionParams()
+        )
+    }
+
+    private fun Map<String, *>.toSendTransaction(): Session.MethodCall.SendTransaction {
+        val params = this["params"] as? List<*> ?: throw IllegalArgumentException("params missing")
+        val data = params.firstOrNull() as? Map<*, *> ?: throw IllegalArgumentException("Invalid params")
+        val from = data["from"] as? String ?: throw IllegalArgumentException("from key missing")
+        val to = data["to"] as? String ?: throw IllegalArgumentException("to key missing")
+        val nonce = data["nonce"] as? String ?: (data["nonce"] as? Double)?.toLong()?.toString()
+        val gasPrice = data["gasPrice"] as? String
+        // "gasLimit" was used in older versions of the library, kept here as a fallback for compatibility
+        val gasLimit = data["gas"] as? String ?: data["gasLimit"] as? String
+        val value = data["value"] as? String ?: "0x0"
+        val txData = data["data"] as? String ?: throw IllegalArgumentException("data key missing")
+        return Session.MethodCall.SendTransaction(getId(), from, to, nonce, gasPrice, gasLimit, value, txData)
+    }
+
+    private fun Map<String, *>.toSignMessage(): Session.MethodCall.SignMessage {
+        val params = this["params"] as? List<*> ?: throw IllegalArgumentException("params missing")
+        val address = params.getOrNull(0) as? String ?: throw IllegalArgumentException("Missing address")
+        val message = params.getOrNull(1) as? String ?: throw IllegalArgumentException("Missing message")
+        return Session.MethodCall.SignMessage(getId(), address, message)
+    }
+
+    private fun Map<String, *>.toCustom(): Session.MethodCall.Custom {
+        val method = this["method"] as? String ?: throw IllegalArgumentException("method missing")
+        val params = this["params"] as? List<*>
+        return Session.MethodCall.Custom(getId(), method, params)
+    }
+
+    private fun Map<String, *>.toResponse(): Session.MethodCall.Response {
+        val result = this["result"]
+        val error = this["error"] as? Map<*, *>
+        if (result == null && error == null) throw IllegalArgumentException("no result or error")
+        return Session.MethodCall.Response(
+            getId(),
+            result,
+            error?.extractError()
+        )
+    }
+
+    protected fun Session.MethodCall.toJsonRpcMap(): Map<String, Any> {
+        return when (this) {
+            is Session.MethodCall.SessionRequest -> this.toMap()
+            is Session.MethodCall.Response -> this.toMap()
+            is Session.MethodCall.SessionUpdate -> this.toMap()
+            is Session.MethodCall.SendTransaction -> this.toMap()
+            is Session.MethodCall.SignMessage -> this.toMap()
+            is Session.MethodCall.Custom -> this.toMap()
+        }
+    }
+
+    private fun Session.MethodCall.SessionRequest.toMap() = jsonRpc(id, "wc_sessionRequest", peer.intoMap())
+
+    private fun Session.MethodCall.SessionUpdate.toMap() = jsonRpc(id, "wc_sessionUpdate", params.intoMap())
+
+    private fun Session.MethodCall.SendTransaction.toMap() = jsonRpc(
+        id,
+        "eth_sendTransaction",
+        mapOf(
+            "from" to from,
+            "to" to to,
+            "nonce" to nonce,
+            "gasPrice" to gasPrice,
+            "gas" to gasLimit,
+            "value" to value,
+            "data" to data
+        )
+    )
+
+    private fun Session.MethodCall.SignMessage.toMap() = jsonRpc(id, "eth_sign", address, message)
+
+    private fun Session.MethodCall.Response.toMap() = mutableMapOf<String, Any>(
+        "id" to id,
+        "jsonrpc" to "2.0"
+    ).apply {
+        result?.let { this["result"] = result }
+        error?.let { this["error"] = error.intoMap() }
+    }
+
+    private fun Session.MethodCall.Custom.toMap() = jsonRpcWithList(id, method, params ?: emptyList<Any>())
+
+    private fun jsonRpc(id: Long, method: String, vararg params: Any) = jsonRpcWithList(id, method, params.asList())
+
+    private fun jsonRpcWithList(id: Long, method: String, params: List<*>) = mapOf(
+        "id" to id,
+        "jsonrpc" to "2.0",
+        "method" to method,
+        "params" to params
+    )
+}

--- a/lib/src/main/kotlin/org/walletconnect/impls/GsonPayloadAdapter.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/GsonPayloadAdapter.kt
@@ -1,0 +1,28 @@
+package org.walletconnect.impls
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import org.walletconnect.EncryptedPayload
+import org.walletconnect.Session
+
+class GsonPayloadAdapter(private val gson: Gson) : BasePayloadAdapter() {
+
+    private val jsonRpcMapTypeToken = object : TypeToken<Map<String, Any?>?>() {}.type
+
+    override fun parse(payload: String, key: String): Session.MethodCall {
+        val encryptedPayload = gson.fromJson(payload, EncryptedPayload::class.java)
+            ?: throw IllegalArgumentException("Invalid json payload!")
+
+        val decryptedPayload = payloadEncryptionHelper.decryptPayload(encryptedPayload, key)
+
+        val payloadJson = String(decryptedPayload)
+        val jsonRpcMap: Map<String, Any>? = gson.fromJson(payloadJson, jsonRpcMapTypeToken)
+        return parseJsonRpcMethodCall(jsonRpcMap)
+    }
+
+    override fun prepare(data: Session.MethodCall, key: String): String {
+        val bytesData = gson.toJson(data.toJsonRpcMap()).toByteArray()
+        val encryptedPayload = payloadEncryptionHelper.encryptPayload(bytesData, key)
+        return gson.toJson(encryptedPayload)
+    }
+}

--- a/lib/src/main/kotlin/org/walletconnect/impls/MoshiPayloadAdapter.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/MoshiPayloadAdapter.kt
@@ -1,23 +1,11 @@
 package org.walletconnect.impls
 
-import com.squareup.moshi.Json
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
-import org.bouncycastle.crypto.digests.SHA256Digest
-import org.bouncycastle.crypto.engines.AESEngine
-import org.bouncycastle.crypto.macs.HMac
-import org.bouncycastle.crypto.modes.CBCBlockCipher
-import org.bouncycastle.crypto.paddings.PKCS7Padding
-import org.bouncycastle.crypto.paddings.PaddedBufferedBlockCipher
-import org.bouncycastle.crypto.params.KeyParameter
-import org.bouncycastle.crypto.params.ParametersWithIV
-import org.komputing.khex.decode
-import org.komputing.khex.extensions.toNoPrefixHexString
+import org.walletconnect.EncryptedPayload
 import org.walletconnect.Session
-import org.walletconnect.types.*
-import java.security.SecureRandom
 
-class MoshiPayloadAdapter(moshi: Moshi) : Session.PayloadAdapter {
+class MoshiPayloadAdapter(moshi: Moshi) : BasePayloadAdapter() {
 
     private val payloadAdapter = moshi.adapter(EncryptedPayload::class.java)
     private val mapAdapter = moshi.adapter<Map<String, Any?>>(
@@ -28,205 +16,20 @@ class MoshiPayloadAdapter(moshi: Moshi) : Session.PayloadAdapter {
         )
     )
 
-    private fun createRandomBytes(i: Int) = ByteArray(i).also { SecureRandom().nextBytes(it) }
-
     override fun parse(payload: String, key: String): Session.MethodCall {
-        val encryptedPayload = payloadAdapter.fromJson(payload) ?: throw IllegalArgumentException("Invalid json payload!")
+        val encryptedPayload = payloadAdapter.fromJson(payload)
+            ?: throw IllegalArgumentException("Invalid json payload!")
 
-        // TODO verify hmac
+        val decryptedPayload = payloadEncryptionHelper.decryptPayload(encryptedPayload, key)
 
-        val padding = PKCS7Padding()
-        val aes = PaddedBufferedBlockCipher(
-            CBCBlockCipher(AESEngine()),
-            padding
-        )
-        val ivAndKey = ParametersWithIV(
-            KeyParameter(decode(key)),
-            decode(encryptedPayload.iv)
-        )
-        aes.init(false, ivAndKey)
-
-        val encryptedData = decode(encryptedPayload.data)
-        val minSize = aes.getOutputSize(encryptedData.size)
-        val outBuf = ByteArray(minSize)
-        var len = aes.processBytes(encryptedData, 0, encryptedData.size, outBuf, 0)
-        len += aes.doFinal(outBuf, len)
-
-        return outBuf.copyOf(len).toMethodCall()
+        val payloadJson = String(decryptedPayload)
+        val jsonRpcMap = mapAdapter.fromJson(payloadJson)
+        return parseJsonRpcMethodCall(jsonRpcMap)
     }
 
     override fun prepare(data: Session.MethodCall, key: String): String {
-        val bytesData = data.toBytes()
-        val hexKey = decode(key)
-        val iv = createRandomBytes(16)
-
-        val padding = PKCS7Padding()
-        val aes = PaddedBufferedBlockCipher(
-            CBCBlockCipher(AESEngine()),
-            padding
-        )
-        aes.init(true, ParametersWithIV(KeyParameter(hexKey), iv))
-
-        val minSize = aes.getOutputSize(bytesData.size)
-        val outBuf = ByteArray(minSize)
-        val length1 = aes.processBytes(bytesData, 0, bytesData.size, outBuf, 0)
-        aes.doFinal(outBuf, length1)
-
-
-        val hmac = HMac(SHA256Digest())
-        hmac.init(KeyParameter(hexKey))
-
-        val hmacResult = ByteArray(hmac.macSize)
-        hmac.update(outBuf, 0, outBuf.size)
-        hmac.update(iv, 0, iv.size)
-        hmac.doFinal(hmacResult, 0)
-
-        return payloadAdapter.toJson(
-            EncryptedPayload(
-                outBuf.toNoPrefixHexString(),
-                hmac = hmacResult.toNoPrefixHexString(),
-                iv = iv.toNoPrefixHexString()
-            )
-        )
+        val bytesData = mapAdapter.toJson(data.toJsonRpcMap()).toByteArray()
+        val encryptedPayload = payloadEncryptionHelper.encryptPayload(bytesData, key)
+        return payloadAdapter.toJson(encryptedPayload)
     }
-
-    /**
-     * Convert FROM request bytes
-     */
-    private fun ByteArray.toMethodCall(): Session.MethodCall =
-        String(this).let { json ->
-            mapAdapter.fromJson(json)?.let {
-                try {
-                    val method = it["method"]
-                    when (method) {
-                        "wc_sessionRequest" -> it.toSessionRequest()
-                        "wc_sessionUpdate" -> it.toSessionUpdate()
-                        "eth_sendTransaction" -> it.toSendTransaction()
-                        "eth_sign" -> it.toSignMessage()
-                        null -> it.toResponse()
-                        else -> it.toCustom()
-                    }
-                } catch (e: Exception) {
-                    throw Session.MethodCallException.InvalidRequest(it.getId(), "$json (${e.message ?: "Unknown error"})")
-                }
-            } ?: throw IllegalArgumentException("Invalid json")
-        }
-
-    private fun Map<String, *>.toSessionUpdate(): Session.MethodCall.SessionUpdate {
-        val params = this["params"] as? List<*> ?: throw IllegalArgumentException("params missing")
-        val data = params.firstOrNull() as? Map<String, *> ?: throw IllegalArgumentException("Invalid params")
-        return Session.MethodCall.SessionUpdate(
-            getId(),
-            data.extractSessionParams()
-        )
-    }
-
-    private fun Map<String, *>.toSendTransaction(): Session.MethodCall.SendTransaction {
-        val params = this["params"] as? List<*> ?: throw IllegalArgumentException("params missing")
-        val data = params.firstOrNull() as? Map<*, *> ?: throw IllegalArgumentException("Invalid params")
-        val from = data["from"] as? String ?: throw IllegalArgumentException("from key missing")
-        val to = data["to"] as? String ?: throw IllegalArgumentException("to key missing")
-        val nonce = data["nonce"] as? String ?: (data["nonce"] as? Double)?.toLong()?.toString()
-        val gasPrice = data["gasPrice"] as? String
-        // "gasLimit" was used in older versions of the library, kept here as a fallback for compatibility
-        val gasLimit = data["gas"] as? String ?: data["gasLimit"] as? String
-        val value = data["value"] as? String ?: "0x0"
-        val txData = data["data"] as? String ?: throw IllegalArgumentException("data key missing")
-        return Session.MethodCall.SendTransaction(getId(), from, to, nonce, gasPrice, gasLimit, value, txData)
-    }
-
-    private fun Map<String, *>.toSignMessage(): Session.MethodCall.SignMessage {
-        val params = this["params"] as? List<*> ?: throw IllegalArgumentException("params missing")
-        val address = params.getOrNull(0) as? String ?: throw IllegalArgumentException("Missing address")
-        val message = params.getOrNull(1) as? String ?: throw IllegalArgumentException("Missing message")
-        return Session.MethodCall.SignMessage(getId(), address, message)
-    }
-
-    private fun Map<String, *>.toCustom(): Session.MethodCall.Custom {
-        val method = this["method"] as? String ?: throw IllegalArgumentException("method missing")
-        val params = this["params"] as? List<*>
-        return Session.MethodCall.Custom(getId(), method, params)
-    }
-
-    private fun Map<String, *>.toResponse(): Session.MethodCall.Response {
-        val result = this["result"]
-        val error = this["error"] as? Map<*, *>
-        if (result == null && error == null) throw IllegalArgumentException("no result or error")
-        return Session.MethodCall.Response(
-            getId(),
-            result,
-            error?.extractError()
-        )
-    }
-
-    /**
-     * Convert INTO request bytes
-     */
-    private fun Session.MethodCall.toBytes() =
-        mapAdapter.toJson(
-            when (this) {
-                is Session.MethodCall.SessionRequest -> this.toMap()
-                is Session.MethodCall.Response -> this.toMap()
-                is Session.MethodCall.SessionUpdate -> this.toMap()
-                is Session.MethodCall.SendTransaction -> this.toMap()
-                is Session.MethodCall.SignMessage -> this.toMap()
-                is Session.MethodCall.Custom -> this.toMap()
-            }
-        ).toByteArray()
-
-    private fun Session.MethodCall.SessionRequest.toMap() =
-        jsonRpc(id, "wc_sessionRequest", peer.intoMap())
-
-    private fun Session.MethodCall.SessionUpdate.toMap() =
-        jsonRpc(id, "wc_sessionUpdate", params.intoMap())
-
-    private fun Session.MethodCall.SendTransaction.toMap() =
-        jsonRpc(
-            id, "eth_sendTransaction", mapOf(
-                "from" to from,
-                "to" to to,
-                "nonce" to nonce,
-                "gasPrice" to gasPrice,
-                "gas" to gasLimit,
-                "value" to value,
-                "data" to data
-            )
-        )
-
-    private fun Session.MethodCall.SignMessage.toMap() =
-        jsonRpc(
-            id, "eth_sign", address, message
-        )
-
-    private fun Session.MethodCall.Response.toMap() =
-        mutableMapOf<String, Any>(
-            "id" to id,
-            "jsonrpc" to "2.0"
-        ).apply {
-            result?.let { this["result"] = result }
-            error?.let { this["error"] = error.intoMap() }
-        }
-
-    private fun Session.MethodCall.Custom.toMap() =
-        jsonRpcWithList(
-            id, method, params ?: emptyList<Any>()
-        )
-
-    private fun jsonRpc(id: Long, method: String, vararg params: Any) =
-        jsonRpcWithList(id, method, params.asList())
-
-    private fun jsonRpcWithList(id: Long, method: String, params: List<*>) =
-        mapOf(
-            "id" to id,
-            "jsonrpc" to "2.0",
-            "method" to method,
-            "params" to params
-        )
-
-    // TODO: @JsonClass(generateAdapter = true)
-    data class EncryptedPayload(
-        @Json(name = "data") val data: String,
-        @Json(name = "iv") val iv: String,
-        @Json(name = "hmac") val hmac: String
-    )
 }

--- a/lib/src/main/kotlin/org/walletconnect/impls/OkHttpTransport.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/OkHttpTransport.kt
@@ -37,8 +37,7 @@ class OkHttpTransport(
             socket ?: run {
                 connected = false
                 val bridgeWS = serverUrl.replace("https://", "wss://").replace("http://", "ws://")
-                socket = client.newWebSocket(Request.Builder().url(bridgeWS).build(), this)
-                return true
+                return tryExec { socket = client.newWebSocket(Request.Builder().url(bridgeWS).build(), this) }
             }
         }
         return false
@@ -68,7 +67,8 @@ class OkHttpTransport(
         mapOf(
             "topic" to topic,
             "type" to type,
-            "payload" to payload
+            "payload" to payload,
+            "silent" to true
         )
 
     override fun close() {
@@ -113,11 +113,13 @@ class OkHttpTransport(
         statusHandler(Disconnected)
     }
 
-    private fun tryExec(block: () -> Unit) {
-        try {
+    private fun tryExec(block: () -> Unit): Boolean {
+        return try {
             block()
+            true
         } catch (e: Exception) {
             statusHandler(Error(e))
+            false
         }
     }
 

--- a/lib/src/main/kotlin/org/walletconnect/impls/OkHttpTransport.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/OkHttpTransport.kt
@@ -99,18 +99,18 @@ class OkHttpTransport(
     override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
         super.onFailure(webSocket, t, response)
         statusHandler(Error(t))
-        disconnected()
+        disconnected(false)
     }
 
     override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
         super.onClosed(webSocket, code, reason)
-        disconnected()
+        disconnected(true)
     }
 
-    private fun disconnected() {
+    private fun disconnected(forceToClearSession: Boolean) {
         socket = null
         connected = false
-        statusHandler(Disconnected)
+        statusHandler(Disconnected(forceToClearSession))
     }
 
     private fun tryExec(block: () -> Unit): Boolean {

--- a/lib/src/main/kotlin/org/walletconnect/impls/OkHttpTransport.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/OkHttpTransport.kt
@@ -72,7 +72,7 @@ class OkHttpTransport(
         )
 
     override fun close() {
-        socket?.close(1000, null)
+        tryExec { socket?.close(1000, null) }
     }
 
     override fun onOpen(webSocket: WebSocket, response: Response) {
@@ -99,18 +99,18 @@ class OkHttpTransport(
     override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
         super.onFailure(webSocket, t, response)
         statusHandler(Error(t))
-        disconnected(false)
+        disconnected(isSessionDeletionNeeded = false)
     }
 
     override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
         super.onClosed(webSocket, code, reason)
-        disconnected(true)
+        disconnected(isSessionDeletionNeeded = true)
     }
 
-    private fun disconnected(forceToClearSession: Boolean) {
+    private fun disconnected(isSessionDeletionNeeded: Boolean) {
         socket = null
         connected = false
-        statusHandler(Disconnected(forceToClearSession))
+        statusHandler(Disconnected(isSessionDeletionNeeded))
     }
 
     private fun tryExec(block: () -> Unit): Boolean {

--- a/lib/src/main/kotlin/org/walletconnect/impls/WCSession.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/WCSession.kt
@@ -71,6 +71,10 @@ class WCSession(
         sessionCallbacks.clear()
     }
 
+    override fun disconnect() {
+        internalClose()
+    }
+
     private fun propagateToCallbacks(action: Session.Callback.() -> Unit) {
         sessionCallbacks.forEach {
             try { it.action() }

--- a/lib/src/main/kotlin/org/walletconnect/impls/WCSession.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/WCSession.kt
@@ -178,7 +178,7 @@ class WCSession(
         propagateToCallbacks {
             onStatus(when(status) {
                 Session.Transport.Status.Connected -> Session.Status.Connected(clientData.id, peerId)
-                Session.Transport.Status.Disconnected -> Session.Status.Disconnected
+                is Session.Transport.Status.Disconnected -> Session.Status.Disconnected(status.forceToClearSession)
                 is Session.Transport.Status.Error -> Session.Status.Error(Session.TransportError(status.throwable))
             })
         }

--- a/lib/src/main/kotlin/org/walletconnect/impls/WCSession.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/WCSession.kt
@@ -178,7 +178,7 @@ class WCSession(
         propagateToCallbacks {
             onStatus(when(status) {
                 Session.Transport.Status.Connected -> Session.Status.Connected(clientData.id, peerId)
-                is Session.Transport.Status.Disconnected -> Session.Status.Disconnected(status.forceToClearSession)
+                is Session.Transport.Status.Disconnected -> Session.Status.Disconnected(status.isSessionDeletionNeeded)
                 is Session.Transport.Status.Error -> Session.Status.Error(Session.TransportError(status.throwable))
             })
         }

--- a/lib/src/main/kotlin/org/walletconnect/impls/WCSession.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/WCSession.kt
@@ -106,7 +106,15 @@ class WCSession(
                     approvedAccounts = params.accounts
                     chainId = params.chainId
                     storeSession()
-                    propagateToCallbacks { onStatus(if (params.approved) Session.Status.Approved else Session.Status.Closed) }
+                    propagateToCallbacks {
+                        onStatus(
+                            if (params.approved){
+                                Session.Status.Approved(clientData.id, peerId)
+                            } else{
+                                Session.Status.Closed
+                            }
+                        )
+                    }
                 }
             })
             handshakeId = requestId
@@ -121,7 +129,7 @@ class WCSession(
         val params = Session.SessionParams(true, chainId, accounts, clientData).intoMap()
         send(Session.MethodCall.Response(handshakeId, params))
         storeSession()
-        propagateToCallbacks { onStatus(Session.Status.Approved) }
+        propagateToCallbacks { onStatus(Session.Status.Approved(clientData.id, peerId)) }
     }
 
     override fun update(accounts: List<String>, chainId: Long) {
@@ -169,7 +177,7 @@ class WCSession(
         }
         propagateToCallbacks {
             onStatus(when(status) {
-                Session.Transport.Status.Connected -> Session.Status.Connected
+                Session.Transport.Status.Connected -> Session.Status.Connected(clientData.id, peerId)
                 Session.Transport.Status.Disconnected -> Session.Status.Disconnected
                 is Session.Transport.Status.Error -> Session.Status.Error(Session.TransportError(status.throwable))
             })

--- a/lib/src/main/kotlin/org/walletconnect/impls/WCSession.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/WCSession.kt
@@ -99,7 +99,7 @@ class WCSession(
     override fun offer() {
         if (transport.connect()) {
             val requestId = createCallId()
-            send(Session.MethodCall.SessionRequest(requestId, clientData), topic = config.handshakeTopic, callback = { resp ->
+            send(Session.MethodCall.SessionRequest(requestId, clientData, chainId), topic = config.handshakeTopic, callback = { resp ->
                 (resp.result as? Map<String, *>)?.extractSessionParams()?.let { params ->
                     peerId = params.peerData?.id
                     peerMeta = params.peerData?.meta
@@ -193,6 +193,7 @@ class WCSession(
                 handshakeId = data.id
                 peerId = data.peer.id
                 peerMeta = data.peer.meta
+                chainId = data.chainId
                 storeSession()
             }
             is Session.MethodCall.SessionUpdate -> {

--- a/lib/src/main/kotlin/org/walletconnect/impls/WCSession.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/WCSession.kt
@@ -109,7 +109,7 @@ class WCSession(
                     propagateToCallbacks {
                         onStatus(
                             if (params.approved){
-                                Session.Status.Approved(clientData.id, peerId)
+                                Session.Status.Approved(clientData.id)
                             } else{
                                 Session.Status.Closed
                             }
@@ -129,7 +129,7 @@ class WCSession(
         val params = Session.SessionParams(true, chainId, accounts, clientData).intoMap()
         send(Session.MethodCall.Response(handshakeId, params))
         storeSession()
-        propagateToCallbacks { onStatus(Session.Status.Approved(clientData.id, peerId)) }
+        propagateToCallbacks { onStatus(Session.Status.Approved(clientData.id)) }
     }
 
     override fun update(accounts: List<String>, chainId: Long) {
@@ -177,7 +177,7 @@ class WCSession(
         }
         propagateToCallbacks {
             onStatus(when(status) {
-                Session.Transport.Status.Connected -> Session.Status.Connected(clientData.id, peerId)
+                Session.Transport.Status.Connected -> Session.Status.Connected(clientData.id)
                 is Session.Transport.Status.Disconnected -> Session.Status.Disconnected(status.isSessionDeletionNeeded)
                 is Session.Transport.Status.Error -> Session.Status.Error(Session.TransportError(status.throwable))
             })

--- a/lib/src/main/kotlin/org/walletconnect/types/TypeMapConversion.kt
+++ b/lib/src/main/kotlin/org/walletconnect/types/TypeMapConversion.kt
@@ -46,7 +46,7 @@ fun Session.SessionParams.intoMap(params: MutableMap<String, Any?> = mutableMapO
 
 fun Map<String, *>.extractSessionParams(): Session.SessionParams {
     val approved = this["approved"] as? Boolean ?: throw IllegalArgumentException("approved missing")
-    val chainId = this["chainId"] as? Long
+    val chainId = (this["chainId"] as? Double)?.toLong()
     val accounts = nullOnThrow { (this["accounts"] as? List<*>)?.toStringList() }
 
     return Session.SessionParams(approved, chainId, accounts, nullOnThrow { this.extractPeerData() })
@@ -59,7 +59,8 @@ fun Map<String, *>.toSessionRequest(): Session.MethodCall.SessionRequest {
 
     return Session.MethodCall.SessionRequest(
             getId(),
-            data.extractPeerData()
+            data.extractPeerData(),
+            data.getChainId()
     )
 }
 
@@ -78,6 +79,7 @@ fun Map<*, *>.extractError(): Session.Error {
 fun Map<String, *>.getId(): Long =
         (this["id"] as? Double)?.toLong() ?: throw IllegalArgumentException("id missing")
 
+fun Map<*, *>.getChainId(): Long? = (this["chainId"] as? Double)?.toLong()
 
 fun List<*>.toStringList(): List<String> =
         this.map {


### PR DESCRIPTION
Since serialize/deserialize adapter wasn't created for Encrypted Payload (it is commented out in `MoshiPayloadAdapter` line 226), we were having issues while working with encrypted payloads. 

Also library forces us to use `Moshi` which we don't use in our project. That's why I've created `GsonPayloadAdapter` but we still need `Moshi` for `FileWCSessionStore`. I am planning to create another `WCSessionStore` that uses `gson` soon.