### PR TITLE
Fixing Double to Long conversion for chainId

### DIFF
--- a/lib/src/main/kotlin/org/walletconnect/types/TypeMapConversion.kt
+++ b/lib/src/main/kotlin/org/walletconnect/types/TypeMapConversion.kt
@@ -46,7 +46,7 @@ fun Session.SessionParams.intoMap(params: MutableMap<String, Any?> = mutableMapO
 
 fun Map<String, *>.extractSessionParams(): Session.SessionParams {
     val approved = this["approved"] as? Boolean ?: throw IllegalArgumentException("approved missing")
-    val chainId = this["chainId"] as? Long
+    val chainId = (this["chainId"] as Double).toLong()
     val accounts = nullOnThrow { (this["accounts"] as? List<*>)?.toStringList() }
 
     return Session.SessionParams(approved, chainId, accounts, nullOnThrow { this.extractPeerData() })


### PR DESCRIPTION
We discovered chainId was always set to null, the reason this was happening was because of a wrong cast from Double to Long.
Another person also reported the issue [here](https://github.com/WalletConnect/kotlin-walletconnect-lib/issues/41)
