### PR TITLE
Add test for parsing session update

### DIFF
--- a/lib/src/main/kotlin/org/walletconnect/impls/MoshiPayloadAdapter.kt
+++ b/lib/src/main/kotlin/org/walletconnect/impls/MoshiPayloadAdapter.kt
@@ -93,7 +93,7 @@ class MoshiPayloadAdapter(moshi: Moshi) : Session.PayloadAdapter {
     /**
      * Convert FROM request bytes
      */
-    private fun ByteArray.toMethodCall(): Session.MethodCall =
+    fun ByteArray.toMethodCall(): Session.MethodCall =
         String(this).let { json ->
             mapAdapter.fromJson(json)?.let {
                 try {

--- a/lib/src/test/java/org/walletconnect/TheWCSession.kt
+++ b/lib/src/test/java/org/walletconnect/TheWCSession.kt
@@ -1,0 +1,39 @@
+package org.walletconnect
+
+import com.squareup.moshi.Moshi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.walletconnect.impls.MoshiPayloadAdapter
+
+
+class TheWCSession {
+
+    @Test
+    fun canParseSessionUpdate() {
+        val adapter = MoshiPayloadAdapter(Moshi.Builder().build())
+        with(adapter) {
+            val json = """{
+                |"id":42,
+                |"result":{},
+                |"method":"wc_sessionUpdate",
+                |"params":[{
+                |  "approved":true,
+                |  "chainId":420,
+                |  "accounts":["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045","0xb8c2c29ee19d8307cb7255e1cd9cbde883a267d5"]
+                |}]
+                |}""".trimMargin()
+            val tested = json.toByteArray().toMethodCall()
+            assertThat(tested).isInstanceOf(Session.MethodCall.SessionUpdate::class.java)
+            assertThat(tested.id()).isEqualTo(42)
+            val testedAndTyped = tested as Session.MethodCall.SessionUpdate
+
+            assertThat(testedAndTyped.params.approved).isTrue
+            assertThat(testedAndTyped.params.accounts).isEqualTo(
+                listOf("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "0xb8c2c29ee19d8307cb7255e1cd9cbde883a267d5")
+            )
+            assertThat(testedAndTyped.params.chainId).isEqualTo(420)
+        }
+
+    }
+}
+


### PR DESCRIPTION
to validate PR #76 - fails currently - will work when #76 is merged

but will wait until we can use VisibleForTesting to not just change visibility for testing without context
unfortunately this is a bigger rabbit hole as the project needs some major dependency updates to get the annotation